### PR TITLE
Fixed workflow for json data in post-requests

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,10 +21,12 @@ def main_consume_api(path):
         payload_file = request.files
         binary_image = cls_api.validate_request(file_=payload_file)
         data = cls_api.format_request(data={**payload_data, **binary_image})
-        cls_api.enqueue_or_write_to_a_file(path=path, data=data)
     else:
-        cls_api.enqueue_or_write_to_a_file(path=path, data=data)
+        data = request.json
 
+    data = {**{"request_type": request.mimetype}, **data}
+
+    cls_api.enqueue_or_write_to_a_file(path=path, data=data)
     message_info = {"message": "Request accepted"}
     return make_response(jsonify(message_info), 202)
 


### PR DESCRIPTION
- Se eliminó linea duplicada 'para encolar' en app.py.
- Se le agrega propiedad 'request_type' al diccionario 'data'.
- Se renombra método 'send_api_data_multuparte' a solo 'send_api_data'.
- La validación del tipo de request se realiza en se mismo método, se elimina la llave del diccionario, y en base a eso se realiza el 'request.post(...)'.
